### PR TITLE
Change ubuntu 14.10 to 14.04 LTS and update wp-cli to 20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.10
+FROM ubuntu:14.04
 MAINTAINER Kai Hofstetter <kai.hofstetter@gmx.de>
 
 # Install lamp stack plus curl
@@ -12,7 +12,7 @@ RUN curl -L "https://wordpress.org/wordpress-4.3.1.tar.gz" > /wordpress-4.3.1.ta
     rm /wordpress-4.3.1.tar.gz
  
 # Download WordPress CLI
-RUN curl -L "https://github.com/wp-cli/wp-cli/releases/download/v0.20.0/wp-cli-0.20.0.phar" > /usr/bin/wp && \
+RUN curl -L "https://github.com/wp-cli/wp-cli/releases/download/v0.20.2/wp-cli-0.20.2.phar" > /usr/bin/wp && \
     chmod +x /usr/bin/wp
 
 # WordPress configuration


### PR DESCRIPTION
Ubuntu 14.10 is deprecated. Support until 2015-07.

https://wiki.ubuntu.com/Releases
