### PR TITLE
add support for installation behind SSL proxy

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -72,6 +72,10 @@ define('WP_DEBUG', false);
 
 /* That's all, stop editing! Happy blogging. */
 
+/** Needed for support behind SSL proxy */
+if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+           $_SERVER['HTTPS']='on';
+
 /** Absolute path to the WordPress directory. */
 if ( !defined('ABSPATH') )
 	define('ABSPATH', dirname(__FILE__) . '/');


### PR DESCRIPTION
If beeing behind a SSL proxy (nginx in my case), wordpress tried to load assets using http instead of https. These lines change the protocol to https if behind a proxy.
